### PR TITLE
feat: add Open API documentation with OASRails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,5 @@ group :development, :test do
 
   gem "dotenv"
 end
+
+gem "oas_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,8 +111,10 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.1)
+    model-to-schema (0.1.2)
     msgpack (1.7.5)
     net-imap (0.5.1)
       date
@@ -130,6 +132,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    oas_rails (0.8.2)
+      method_source (~> 1.0)
+      model-to-schema (~> 0.1.2)
+      yard (~> 0.9)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -225,6 +231,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yard (0.9.37)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -237,6 +244,7 @@ DEPENDENCIES
   brakeman
   debug
   dotenv
+  oas_rails
   puma (>= 5.0)
   rails (~> 7.2.2)
   rubocop-rails-omakase

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -2,7 +2,6 @@ class ReportsController < ApplicationController
   # @summary Creates an attendance or ticket report
   # @tags Reports
   def create
-    render json: params
   end
 
   # @summary Get an event's reports history

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,10 +1,17 @@
 class ReportsController < ApplicationController
+  # @summary Creates an attendance or ticket report
+  # @tags Reports
   def create
+    render json: params
   end
 
+  # @summary Get an event's reports history
+  # @tags Reports
   def get_history
   end
 
+  # @summary Schedule the generation of a report
+  # @tags Reports
   def schedule
   end
 end

--- a/config/initializers/oas_rails.rb
+++ b/config/initializers/oas_rails.rb
@@ -1,0 +1,85 @@
+# config/initializers/oas_rails.rb
+OasRails.configure do |config|
+  # Basic Information about the API
+  config.info.title = "Events Reporting API"
+  config.info.version = "1.0.0"
+  config.info.summary = "OasRails: Automatic Interactive API Documentation for Rails"
+  config.info.description = <<~HEREDOC
+    # Events Reporting API
+
+    This is the endpoints documentation of the Events Reporting API.
+
+    Here you will find all the endpoints that you can use to manage reports from the Events app.
+
+  HEREDOC
+  config.info.contact.name = "Events App Dev Team"
+  config.info.contact.email = "email@example.com"
+  config.info.contact.url = "https://example.com"
+
+  # Servers Information. For more details follow: https://spec.openapis.org/oas/latest.html#server-object
+  config.servers = [ { url: "http://localhost:#{ENV.fetch("PORT", 3000)}", description: "Local" } ]
+
+  # Tag Information. For more details follow: https://spec.openapis.org/oas/latest.html#tag-object
+  config.tags = [ { name: "Reports", description: "Manage the reports." } ]
+
+  # Optional Settings (Uncomment to use)
+
+  # Extract default tags of operations from namespace or controller. Can be set to :namespace or :controller
+  # config.default_tags_from = :namespace
+
+  # Automatically detect request bodies for create/update methods
+  # Default: true
+  # config.autodiscover_request_body = false
+
+  # Automatically detect responses from controller renders
+  # Default: true
+  # config.autodiscover_responses = false
+
+  # API path configuration if your API is under a different namespace
+  # config.api_path = "/"
+
+  # Apply your custom layout. Should be the name of your layout file
+  # Example: "application" if file named application.html.erb
+  # Default: false
+  # config.layout = "application"
+
+  # Excluding custom controlers or controlers#action
+  # Example: ["projects", "users#new"]
+  # config.ignored_actions = []
+
+  # #######################
+  # Authentication Settings
+  # #######################
+
+  # Whether to authenticate all routes by default
+  # Default is true; set to false if you don't want all routes to include secutrity schemas by default
+  # config.authenticate_all_routes_by_default = true
+
+  # Default security schema used for authentication
+  # Choose a predefined security schema
+  # [:api_key_cookie, :api_key_header, :api_key_query, :basic, :bearer, :bearer_jwt, :mutual_tls]
+  # config.security_schema = :bearer
+
+  # Custom security schemas
+  # You can uncomment and modify to use custom security schemas
+  # Please follow the documentation: https://spec.openapis.org/oas/latest.html#security-scheme-object
+  #
+  # config.security_schemas = {
+  #  bearer:{
+  #   "type": "apiKey",
+  #   "name": "api_key",
+  #   "in": "header"
+  #  }
+  # }
+
+  # ###########################
+  # Default Responses (Errors)
+  # ###########################
+
+  # The default responses errors are setted only if the action allow it.
+  # Example, if you add forbidden then it will be added only if the endpoint requires authentication.
+  # Example: not_found will be setted to the endpoint only if the operation is a show/update/destroy action.
+  # config.set_default_responses = true
+  # config.possible_default_responses = [:not_found, :unauthorized, :forbidden]
+  # config.response_body_of_default = { message: String }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,12 @@
 Rails.application.routes.draw do
+  get "/" => redirect("/docs")
+
+  # Open API documentation
+  mount OasRails::Engine => "/docs"
+
+  # App Endpoints
+  get "/test/:id" => "reports#demo_event_service", as: :test
+  get "/demo-create-report" => "reports#demo_create_report", as: :demo_create_report
   post "/events/:event_id/reports" => "reports#create", as: :event_reports
   get "/events/:event_id/reports/get_history" => "reports#get_history", as: :event_reports_history
   put "/events/:event_id/reports/schedule" => "reports#schedule", as: :event_reports_schedule
@@ -7,7 +15,4 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end


### PR DESCRIPTION
### What does this do

- Sets up `oas_rails` with simple description and `"Reports"` tag.
- Adds simple summary and tag to reports endpoints.
- The root path (`"/"`) redirects to the Open API docs