### PR TITLE
feat: integrate schedue endpoint with report ticket service

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -88,21 +88,22 @@ class ReportsController < ApplicationController
   # @summary Schedule the generation of a report
   # @tags Reports
   def schedule
-    event_id = 1
-    frequency = "weekly"
-
+    event_id = schedule_report_params[:event_id]
+    frequency = schedule_report_params[:frequency]
+    p [ "event_id", event_id ]
     # Check if the event exists
-    # event = Event.find_by(id: event_id)
-    # unless event
-    #   render json: { error: "Event not found" }, status: :not_found
-    #   return
-    # end
+    event = EventsService.find_by_id(event_id)
+    p [ "Event", event ]
+    unless event
+      render json: { error: "Event not found" }, status: :not_found
+      return
+    end
 
-    # # Check if the frequency is valid
-    # unless %w[daily weekly monthly].include?(frequency)
-    #   render json: { error: "Invalid frequency" }, status: :unprocessable_entity
-    #   return
-    # end
+    # Check if the frequency is valid
+    unless %w[daily weekly monthly].include?(frequency)
+      render json: { error: "Invalid frequency" }, status: :unprocessable_entity
+      return
+    end
 
     case frequency
 
@@ -124,5 +125,9 @@ class ReportsController < ApplicationController
   private
   def report_params
     params.permit(:type, :user_id, :format, :event_id, report: [ :format ])
+  end
+
+  def schedule_report_params
+    params.permit(:event_id, :frequency, :user_id, report: [:type, :format])
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -128,6 +128,10 @@ class ReportsController < ApplicationController
   end
 
   def schedule_report_params
-    params.permit(:event_id, :frequency, :user_id, report: [:type, :format])
+    params.require(:event_id)
+    params.require(:frequency)
+    params.require(:user_id)
+    params.require(:format)
+    params.permit(:event_id, :frequency, :user_id, :format, report: [ :type, :format ])
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -98,10 +98,7 @@ class ReportsController < ApplicationController
   end
 
   def schedule_report_params
-    params.require(:event_id)
-    params.require(:frequency)
-    params.require(:user_id)
-    params.require(:format)
-    params.permit(:event_id, :frequency, :user_id, :format, report: [ :type, :format ])
+    params.require([ :event_id, :frequency, :user_id, :format ])
+    params.permit(:event_id, :frequency, :user_id, :format, report: {})
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -78,7 +78,6 @@ class ReportsController < ApplicationController
     p [ "event_id", event_id ]
     # Check if the event exists
     event = EventsService.find_by_id(event_id)
-    p [ "Event", event ]
     unless event
       render json: { error: "Event not found" }, status: :not_found
       return
@@ -90,21 +89,7 @@ class ReportsController < ApplicationController
       return
     end
 
-    case frequency
-
-    when "daily"
-      # Schedule the job to run again every day at the same time (i.e., 24 hours later).
-      ReportSchedulerJob.perform_async(event_id, "daily")
-    when "weekly"
-      # Schedule the job to run again every week at the same day and time.
-      ReportSchedulerJob.perform_async(event_id, "weekly")
-    when "monthly"
-      # Schedule the job to run again every month at the same day and time.
-      ReportSchedulerJob.perform_async(event_id, "monthly")
-    else
-      # Handle the case where an unsupported frequency is passed
-      logger.error("Unsupported frequency: #{frequency} for event ID #{event_id}. Job will not be rescheduled.")
-    end
+    ReportSchedulerJob.perform_async(event_id, frequency, format)
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -70,21 +70,6 @@ class ReportsController < ApplicationController
   def get_history
   end
 
-  def delete
-    event_id = 1
-    # Loop through all jobs in the Scheduled Set
-    Sidekiq::ScheduledSet.new.each do |job|
-      # Check if the job's arguments match the ones you're looking for
-      if job.args[0] == event_id
-        # Found a matching job, so you can delete it
-        job.delete
-        logger.info("Job with JID #{job.jid} has been deleted. Event ID: #{event_id}")
-        return job.jid  # Optionally return the JID for reference
-      end
-    end
-  end
-
-
   # @summary Schedule the generation of a report
   # @tags Reports
   def schedule

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -75,7 +75,7 @@ class ReportsController < ApplicationController
   def schedule
     event_id = schedule_report_params[:event_id]
     frequency = schedule_report_params[:frequency]
-    p [ "event_id", event_id ]
+    format = schedule_report_params[:format]
     # Check if the event exists
     event = EventsService.find_by_id(event_id)
     unless event

--- a/app/sidekiq/report_scheduler_job.rb
+++ b/app/sidekiq/report_scheduler_job.rb
@@ -1,8 +1,12 @@
+require "prawn"
+require "prawn/table"
+
 class ReportSchedulerJob
   include Sidekiq::Job
 
-  def perform(event_id, frequency)
-    # TicketsService.createReport  --create the logic
+  def perform(event_id, frequency, format)
+    params = { event_id: event_id, format: format }
+    TicketsService.create_report(params)
     logger.info("report scheduled")
 
     # Determine the interval in seconds based on the frequency

--- a/app/sidekiq/report_scheduler_job.rb
+++ b/app/sidekiq/report_scheduler_job.rb
@@ -20,7 +20,7 @@ class ReportSchedulerJob
     # Schedule the next job if interval_in_seconds is greater than 0
     if interval_in_seconds > 0
       find_and_cancel_job(event_id)
-      schedule_next_job(interval_in_seconds, event_id, frequency)
+      schedule_next_job(interval_in_seconds, event_id, frequency, format)
     else
       logger.info("No rescheduling necessary.")
     end
@@ -43,12 +43,12 @@ class ReportSchedulerJob
   end
 
   # Helper method to reschedule the job at a fixed interval
-  def schedule_next_job(interval_in_seconds, event_id, frequency)
+  def schedule_next_job(interval_in_seconds, event_id, frequency, format)
     # Calculate the next run time by adding the interval (in seconds) to the current time
     next_run_time = Time.now + interval_in_seconds
 
     # Schedule the next job at the exact time (this keeps it consistent)
-    self.class.perform_at(next_run_time, event_id, frequency)
+    self.class.perform_at(next_run_time, event_id, frequency, format)
 
     # Output the next scheduled time for logging or debugging
     logger.info("Next #{frequency} job scheduled at: #{next_run_time}")

--- a/app/sidekiq/report_scheduler_job.rb
+++ b/app/sidekiq/report_scheduler_job.rb
@@ -1,6 +1,3 @@
-require "prawn"
-require "prawn/table"
-
 class ReportSchedulerJob
   include Sidekiq::Job
 

--- a/app/sidekiq/report_scheduler_job.rb
+++ b/app/sidekiq/report_scheduler_job.rb
@@ -16,7 +16,7 @@ class ReportSchedulerJob
 
     # Schedule the next job if interval_in_seconds is greater than 0
     if interval_in_seconds > 0
-      find_and_cancel_job(event_id)
+      find_and_cancel_job(event_id: event_id, format: format)
       schedule_next_job(interval_in_seconds, event_id, frequency, format)
     else
       logger.info("No rescheduling necessary.")
@@ -26,11 +26,11 @@ class ReportSchedulerJob
   private
 
   # Method to find and cancel an existing scheduled job
-  def find_and_cancel_job(event_id)
+  def find_and_cancel_job(event_id:, format:)
     # Loop through all jobs in the Scheduled Set
     Sidekiq::ScheduledSet.new.each do |job|
       # Check if the job's arguments match the ones you're looking for
-      if job.args[0] == event_id
+      if job.args[0] == event_id && job.args[2] == format
         # Found a matching job, so you can delete it
         job.delete
         logger.info("Job with JID #{job.jid} has been deleted. Event ID: #{event_id}")


### PR DESCRIPTION
What does this do

- cleans the endpoints and erases unused ones
- integrates the schedule endpoint with the events and tickets services
- Allows scheduling multiple reports of the same event in different formats.